### PR TITLE
accomodate both Python 2 and 3

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -36,7 +36,8 @@ extensions = [
 ]
 
 intersphinx_mapping = {
-    'python': ('http://docs.python.org/3.2', None),
+    'python': ('http://docs.python.org', None),
+    'python3': ('http://docs.python.org/3', None),
     'pyramid':
         ('http://docs.pylonsproject.org/projects/pyramid/en/latest/',
          None)


### PR DESCRIPTION
With this change, those building using Python 2 will get references pointing to Python 2 docs. Same applies to Python 3.
