### PR TITLE
Central index of Pyramid tutorials

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -1,29 +1,94 @@
+=================
 Pyramid Tutorials
 =================
 
-This is the home of tutorial and patterns content for the Pyramid web framework.
+This is the home of tutorial and patterns content for the Pyramid web
+framework.
 
-Contents
----------
+
+---------------------------
+Contents of this repository
+---------------------------
 
 .. toctree::
    :maxdepth: 1
-   
+
    single_file_tasks/single_file_tasks
-   wiki_tutorials
    humans/index
    getting_started/index
-   
-Additional learning resources
-.............................
-
-* `Pyramid Blog Tutorial <http://pyramid-blogr.readthedocs.org/en/latest/>`_
 
 
 .. toctree::
    :hidden:
 
    README
+
+
+---------------------------
+Available Pyramid tutorials
+---------------------------
+
+Several Pyramid tutorials exist. Some are part of the main
+`Pyramid Documentation`_, some are in this `Pyramid Tutorials`_
+community project, and others are published elsewhere.
+
+.. _Pyramid Documentation: http://docs.pylonsproject.org/en/latest/docs/pyramid.html
+.. _Pyramid Tutorials: http://docs.pylonsproject.org/projects/pyramid/en/1.4-branch/#tutorials
+
+
+These are the Pyramid tutorials we could locate during the PyCon USA sprints in March, 2013.
+
+**ET** is the estimated time to complete each tutorial.
+
+================== === ======================= =============================== ==================== ===============
+name/link          ET* title                   description                     code repo            features
+================== === ======================= =============================== ==================== ===============
+`firstapp`_        1h  Creating Your First     chapter 4 in the
+                       Pyramid Application     `Narrative Documentation`_ part `pyramid`_           * URL dispatch
+                                               of the main Pyramid docs
+
+`wiki`_            4h  ZODB + Traversal Wiki   chapter 37 in the `Tutorials`_  `pyramid`_           * traversal
+                       Tutorial                part of the main Pyramid docs                        * ZODB
+
+`wiki2`_           4h  SQLAlchemy + URL        chapter 38 in the `Tutorials`_  `pyramid`_           * URL dispatch
+                       Dispatch Wiki Tutorial  part of the main Pyramid docs                        * SQLAlchemy
+
+`single_file`_     ?   Todo List Application   very short; a.k.a. The Single   `pyramid_tutorials`_
+                       in One File             ``tasks`` Tutorial              (this site)
+
+`humans`_          12h Pyramid for Plone       Pyramid for Plone Developers    `pyramid_tutorials`_
+                       Developers                                              (this site)
+
+`getting_started`_ 5h  Getting Started with    Presented by Paul Everitt at    `pyramid_tutorials`_ * URL dispatch
+                       Pyramid                 PyCon USA 2013                  (this site)          * SQLAlchemy
+                                                                                                    * Chameleon
+                                                                                                    * security
+
+`blogr`_           ?   ``pyramid_blogr``       inspired by Flaskr app from the `pyramid_blogr`_
+                       Tutorial                Flask Web Framework Tutorial
+
+`birdie`_          4h  Birdie Tutorial: a      presented by Carlos de la
+                       simple Twitter clone    Guardia at OSCON 2011 and PyCon `cguardia_tut`_
+                                               USA 2012
+================== === ======================= =============================== ==================== ===============
+
+.. _firstapp: http://docs.pylonsproject.org/projects/pyramid/en/1.4-branch/narr/firstapp.html
+.. _wiki: http://docs.pylonsproject.org/projects/pyramid/en/1.4-branch/tutorials/wiki/index.html
+.. _wiki2: http://docs.pylonsproject.org/projects/pyramid/en/1.4-branch/tutorials/wiki2/index.html
+.. _single_file: http://docs.pylonsproject.org/projects/pyramid_tutorials/en/latest/single_file_tasks/single_file_tasks.html
+.. _humans: http://docs.pylonsproject.org/projects/pyramid_tutorials/en/latest/humans/index.html
+.. _getting_started: http://docs.pylonsproject.org/projects/pyramid_tutorials/en/latest/getting_started/index.html
+.. _blogr: http://pyramid-blogr.readthedocs.org/en/latest/
+.. _birdie: https://github.com/cguardia/Pyramid-Tutorial/blob/master/presentation/pyramid_tutorial.pdf
+
+.. _Narrative Documentation: http://docs.pylonsproject.org/projects/pyramid/en/1.4-branch/#narrative-documentation
+.. _Tutorials: http://docs.pylonsproject.org/projects/pyramid/en/1.4-branch/#tutorials
+
+.. _pyramid: https://github.com/Pylons/pyramid
+.. _pyramid_tutorials: https://github.com/Pylons/pyramid_tutorials
+.. _pyramid_blogr: https://github.com/Pylons/pyramid_blogr
+.. _cguardia_tut: https://github.com/cguardia/Pyramid-Tutorial
+
 
 Indices and tables
 ==================

--- a/wiki_tutorials.rst
+++ b/wiki_tutorials.rst
@@ -1,9 +1,0 @@
-Wiki Tutorials
-==============
-
-Detailed tutorials explaining how to use Pyramid to build various types of 
-applications and how to deploy Pyramid applications to various platforms.
-
-* `SQLAlchemy + URL Dispatch Wiki Tutorial <http://docs.pylonsproject.org/projects/pyramid/en/1.3-branch/tutorials/wiki2/index.html>`_
-
-* `ZODB + Traversal Wiki Tutorial <http://docs.pylonsproject.org/projects/pyramid/en/1.3-branch/tutorials/wiki/index.html>`_


### PR DESCRIPTION
- added listing to index.rst pointing to all known Pyramid tutorials
- removed wiki_tutorials.rst page, now redundant
