### PR TITLE
Updated link to documentation in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 Pyramid Tutorials
 =================
 
-This is a work in progress to create tutorials for Pyramid.
+A `listing of tutorials <http://docs.pylonsproject.org/projects/pyramid-tutorials/en/latest/>`_ for Pyramid.
 
-See the http://docs.pylonshq.com/ for documentation. 
+Read `documentation of the Pyramid web application framework <http://docs.pylonsproject.org/projects/pyramid/en/latest/>`_.


### PR DESCRIPTION
http://docs.pylonshq.com/ seems to be down.

So, updated URL to http://docs.pylonsproject.org/projects/pyramid-tutorials/en/latest/.
