### PR TITLE
- :linenos: not :lineos:, Fixes #86

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 Pyramid Tutorials
 =================
 
-A `listing of tutorials <http://docs.pylonsproject.org/projects/pyramid-tutorials/en/latest/>`_ for Pyramid.
+A `listing of tutorials
+<http://docs.pylonsproject.org/projects/pyramid-tutorials/en/latest/>`_ for
+Pyramid.
 
-Read `documentation of the Pyramid web application framework <http://docs.pylonsproject.org/projects/pyramid/en/latest/>`_.
+Read `documentation of the Pyramid web application framework
+<http://docs.pylonsproject.org/projects/pyramid/en/latest/>`_.

--- a/getting_started/06-template/index.rst
+++ b/getting_started/06-template/index.rst
@@ -30,25 +30,26 @@ Steps
     
 #. Since we are using Chameleon, ``tutorial/__init__.py`` needs an additional
    configuration:
-  .. literalinclude:: tutorial/__init__.py
-    :lineos:
+   
+   .. literalinclude:: tutorial/__init__.py
+       :linenos:
 
 #. Our ``tutorial/views.py`` is now data-centric:
 
    .. literalinclude:: tutorial/views.py
-    :linenos:
+       :linenos:
 
 #. Create a Chameleon template in ``tutorial/templates/wiki_view.pt``:
 
-    .. literalinclude:: tutorial/templates/wiki_view.pt
-        :language: html
-        :linenos:
+   .. literalinclude:: tutorial/templates/wiki_view.pt
+       :language: html
+       :linenos:
 
 #. Our ``tutorial/tests.py`` has a unit test which is also now
    data-centric:
 
-    .. literalinclude:: tutorial/tests.py
-        :linenos:
+   .. literalinclude:: tutorial/tests.py
+       :linenos:
 
 #. Run the tests in your package using ``nose``:
 


### PR DESCRIPTION
- make spacing consistent between directives
- wrap README.rst to 79 characters