### PR TITLE
Remove SPHINXOPTS = -E option to be consistent with Pyramid's Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W -E
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build


### PR DESCRIPTION
This reverts an earlier change from when I was flailing about trying to fix output on RTD, when it turned out to be a problem with changes at RTD.