### PR TITLE
blogr tutorial now uses Jinja2 instead of mako

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -45,7 +45,7 @@ name/link          ET* title                   description                     c
 
 `blogr`_           4h  ``pyramid_blogr``       inspired by Flaskr app from the `pyramid_blogr`_     * URL dispatch
                        Tutorial                Flask Web Framework Tutorial                         * SQLAlchemy
-                                                                                                    * Mako
+                                                                                                    * Jinja2
                                                                                                     * security
                                                                                                     * WTForms
                                                                                                     * pagination


### PR DESCRIPTION
I noticed an incongruence between the tutorial and the tutorial listing so I figured I would edit it and propose a file change.