### PR TITLE
Update the link and information for the Talk Python RESTful and HTTP APIs in Pyramid course

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -57,7 +57,7 @@ name/link          ET* title                   description                     c
                                                formats (e.g., JSON, XML, HTML,
                                                SOAP)
 
-`restful`_         5h  RESTful and HTTP        Build RESTful services using    `mikeckennedy_restful`_
+`restful`_         8h  RESTful and HTTP        Build RESTful services using    `mikeckennedy_restful`_
                        APIs in Pyramid         Pyramid and SQLAlchemy
 
 `talk_python`_     5h  Building data-driven    Build modern data-driven web    Coming Soon

--- a/index.rst
+++ b/index.rst
@@ -30,23 +30,23 @@ The source of various tutorials is noted under the column "code repo".
 
 **ET** is the estimated time to complete each tutorial.
 
-================== === ======================= =============================== ==================== ========================================
-name/link          ET* title                   description                     code repo            features
-================== === ======================= =============================== ==================== ========================================
-`quick_tutorial`_  8h  Quick Tutorial for      Introduction to and high-level  `pyramid`_           * Most, if not all
+================== === ======================= =============================== ======================= ========================================
+name/link          ET* title                   description                     code repo               features
+================== === ======================= =============================== ======================= ========================================
+`quick_tutorial`_  8h  Quick Tutorial for      Introduction to and high-level  `pyramid`_              * Most, if not all
                        Pyramid                 tour of Pyramid's major
                                                features.
 
-`firstapp`_        1h  Creating Your First     "Hello World"                   `pyramid`_           * URL dispatch
+`firstapp`_        1h  Creating Your First     "Hello World"                   `pyramid`_              * URL dispatch
                        Pyramid Application
 
-`wiki`_            4h  ZODB + Traversal Wiki   Create a wiki using ZODB and    `pyramid`_           * traversal
-                       Tutorial                traversal                                            * ZODB
-                                                                                                    * security
+`wiki`_            4h  ZODB + Traversal Wiki   Create a wiki using ZODB and    `pyramid`_              * traversal
+                       Tutorial                traversal                                               * ZODB
+                                                                                                       * security
 
-`wiki2`_           4h  SQLAlchemy + URL        Create a wiki using SQLAlchemy  `pyramid`_           * URL dispatch
-                       Dispatch Wiki Tutorial  and URL dispatch                                     * SQLAlchemy
-                                                                                                    * security
+`wiki2`_           4h  SQLAlchemy + URL        Create a wiki using SQLAlchemy  `pyramid`_              * URL dispatch
+                       Dispatch Wiki Tutorial  and URL dispatch                                        * SQLAlchemy
+                                                                                                       * security
 
 `entrepreneurs`_   15h Python for              Build an ecommerce app for a    `mikeckennedy_ent`_
                        Entrepreneurs           rock band, with good marketing
@@ -57,8 +57,8 @@ name/link          ET* title                   description                     c
                                                formats (e.g., JSON, XML, HTML,
                                                SOAP)
 
-`talk_python`_     5h  RESTful and HTTP APIs   Build RESTful services using    Coming Soon
-                       in Pyramid              Pyramid and SQLAlchemy
+`restful`_         5h  RESTful and HTTP        Build RESTful services using    `mikeckennedy_restful`_
+                       APIs in Pyramid         Pyramid and SQLAlchemy
 
 `talk_python`_     5h  Building data-driven    Build modern data-driven web    Coming Soon
                        web applications with   applications
@@ -68,12 +68,12 @@ name/link          ET* title                   description                     c
                        simple Twitter clone    Guardia at OSCON 2011 and PyCon `cguardia_tut`_
                                                USA 2012
 
-`blogr`_           4h  ``pyramid_blogr``       inspired by Flaskr app from the `pyramid_blogr`_     * URL dispatch
-                       Tutorial                Flask Web Framework Tutorial                         * SQLAlchemy
-                                                                                                    * Jinja2
-                                                                                                    * security
-                                                                                                    * WTForms
-                                                                                                    * pagination
+`blogr`_           4h  ``pyramid_blogr``       inspired by Flaskr app from the `pyramid_blogr`_        * URL dispatch
+                       Tutorial                Flask Web Framework Tutorial                            * SQLAlchemy
+                                                                                                       * Jinja2
+                                                                                                       * security
+                                                                                                       * WTForms
+                                                                                                       * pagination
 
 `pycharm`_         1h  Using PyCharm with      A getting started guide         `pyramid_cookbook`_
                        Pyramid                 for Pyramid using PyCharm
@@ -81,22 +81,22 @@ name/link          ET* title                   description                     c
 `single_file`_     2h  Todo List Application   very short; a.k.a. The Single   `pyramid_cookbook`_
                        in One File             File ``tasks`` Tutorial
 
-`todopyramid`_     4h  ``ToDo Pyramid App``    ToDo App from Python Web        `todopyramid`_       * URL dispatch
-                       Tutorial                Shootout by SixFeet, Inc                             * SQLAlchemy
-                                               Demo here:                                           * Deform (with bootstrap)
-                                               http://demo.todo.sixfeetup.com                       * Chameleon
-                                                                                                    * Mozilla Persona (using pyramid_persona)
-                                                                                                    * WebHelpers
-                                                                                                    * Custom NotFound view
+`todopyramid`_     4h  ``ToDo Pyramid App``    ToDo App from Python Web        `todopyramid`_          * URL dispatch
+                       Tutorial                Shootout by SixFeet, Inc                                * SQLAlchemy
+                                               Demo here:                                              * Deform (with bootstrap)
+                                               http://demo.todo.sixfeetup.com                          * Chameleon
+                                                                                                       * Mozilla Persona (using pyramid_persona)
+                                                                                                       * WebHelpers
+                                                                                                       * Custom NotFound view
 
-`traversal`_       2d  Quick Tutorial for      Overview of traversal:          `pyramid_cookbook`_  * Site root
-                       Traversal               Hierarchies, views, etc.                             * Hierarchy
-                                                                                                    * Type-specific views
-                                                                                                    * Adding content
-                                                                                                    * ZODB persistence
-                                                                                                    * SQL persistence
-                                                                                                    * SQLAlchemy
-================== === ======================= =============================== ==================== ========================================
+`traversal`_       2d  Quick Tutorial for      Overview of traversal:          `pyramid_cookbook`_     * Site root
+                       Traversal               Hierarchies, views, etc.                                * Hierarchy
+                                                                                                       * Type-specific views
+                                                                                                       * Adding content
+                                                                                                       * ZODB persistence
+                                                                                                       * SQL persistence
+                                                                                                       * SQLAlchemy
+================== === ======================= =============================== ======================= ========================================
 
 .. _quick_tutorial: https://docs.pylonsproject.org/projects/pyramid/en/latest/quick_tutorial/index.html
 .. _firstapp: https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/firstapp.html
@@ -104,6 +104,7 @@ name/link          ET* title                   description                     c
 .. _wiki2: https://docs.pylonsproject.org/projects/pyramid/en/latest/tutorials/wiki2/index.html
 .. _entrepreneurs: https://training.talkpython.fm/courses/explore_entrepreneurs/python-for-entrepreneurs-build-and-launch-your-online-business
 .. _consuming_http: https://training.talkpython.fm/courses/explore_http_reset_client_course/consuming-http-and-soap-services-in-python-with-json-xml-and-screen-scraping
+.. _restful: https://training.talkpython.fm/courses/explore_restful_pyramid_course/creating-a-restful-http-api-with-pyramid-and-python-mega-course
 .. _talk_python: https://training.talkpython.fm/courses/all
 .. _birdie: https://github.com/cguardia/Pyramid-Tutorial
 .. _blogr: https://docs.pylonsproject.org/projects/pyramid-blogr/en/latest/
@@ -118,6 +119,7 @@ name/link          ET* title                   description                     c
 .. _pyramid_blogr: https://docs.pylonsproject.org/projects/pyramid-blogr/en/latest/
 .. _mikeckennedy_ent: https://github.com/mikeckennedy/python-for-entrepreneurs-course-demos
 .. _mikeckennedy_http: https://github.com/mikeckennedy/consuming_services_python_demos
+.. _mikeckennedy_restful: https://github.com/mikeckennedy/restful-services-in-pyramid
 .. _cguardia_tut: https://github.com/cguardia/Pyramid-Tutorial
 
 Indices and tables


### PR DESCRIPTION
Add the link to the course homepage and the Github repository for
Michael Kennedy's Talk Python course RESTful and HTTP APIs in Pyramid
(as the course is now out and not coming soon.)
Update the table to fit the course link.  Update the course estimation time from 5h to 8h to match the marketing page for the RESTful and HTTP APIs in Pyramid course on Talk Python.

I thought I might have made a mistake as the bullet points under "features" look a little off center, but they do on https://docs.pylonsproject.org/projects/pyramid-tutorials/en/latest/ as well.

Please give me any feedback if anything is incorrect.  Sphinx successfully built the pages without any errors.